### PR TITLE
Implement deposit and withdrawal export

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,18 @@
+[style]
+based_on_style = google
+spaces_before_comment = 4
+column_limit = 120
+allow_multiline_dictionary_keys = true
+allow_multiline_lambdas = true
+dedent_closing_brackets =true
+indent_dictionary_value = true
+split_before_dict_set_generator = true
+split_before_logical_operator = true
+split_complex_comprehension = true
+allow_split_before_default_or_named_assigns = true
+allow_split_before_dict_value=true
+coalesce_brackets = true
+force_multiline_dict = true
+join_multiple_lines = false
+split_before_named_assigns = true
+split_all_top_level_comma_separated_values = true

--- a/deltaconv/converter.py
+++ b/deltaconv/converter.py
@@ -16,51 +16,39 @@ import argparse
 import logging
 import sys
 
-from deltaconv.parser.binance import BinanceTradeParser, BinanceCrawlerTradeParser, BinanceCrawlerDepositParser, \
-    BinanceDepositParser
+from deltaconv.parser.binance import BinanceTradeParser, BinanceCrawlerTradeParser, BinanceCrawlerDepositParser, BinanceDepositParser
 from deltaconv.parser.bitpanda import BitpandaParser
 from deltaconv.parser.delta import DeltaParser
 from deltaconv.parser.parser import ParserOutdatedError
 
 PARSER = {
     'binance-trades': {
-        'parser': BinanceTradeParser,
-        'config': {
+        'parser': BinanceTradeParser, 'config': {
             'delimiter': ",",
         }
     },
-
     'binance-deposit': {
-        'parser': BinanceDepositParser,
-        'config': {
+        'parser': BinanceDepositParser, 'config': {
             'delimiter': ",",
         }
     },
-
     'delta': {
-        'parser': DeltaParser,
-        'config': {
+        'parser': DeltaParser, 'config': {
             'delimiter': ',',
         }
     },
-
     'binancecrawler-trades': {
-        'parser': BinanceCrawlerTradeParser,
-        'config': {
+        'parser': BinanceCrawlerTradeParser, 'config': {
             'delimiter': ';',
         }
     },
-
     'binancecrawler-deposit': {
-        'parser': BinanceCrawlerDepositParser,
-        'config': {
+        'parser': BinanceCrawlerDepositParser, 'config': {
             'delimiter': ';',
         }
     },
-
     'bitpanda': {
-        'parser': BitpandaParser,
-        'config': {
+        'parser': BitpandaParser, 'config': {
             'delimiter': ','
         }
     }
@@ -74,16 +62,22 @@ def parse_arguments():
     """Parses the arguments the user passed to this script """
 
     # parse parameter
-    arg_parser = argparse.ArgumentParser(description='''
+    arg_parser = argparse.ArgumentParser(
+        description='''
             This tool parses a range of CSV|XLSX files into other CSV|XLSX file formats, e.g. Delta, Bitpanda or 
-            Binance.''')
+            Binance.'''
+    )
 
     arg_parser.add_argument('--file', help="The csv file", required=True)
 
     arg_parser.add_argument('--format', help="The output transaction format.", required=True, choices=PARSER.keys())
 
-    arg_parser.add_argument('--output', help="The name of the file to save the transactions into without extension.",
-                            required=False, default=None)
+    arg_parser.add_argument(
+        '--output',
+        help="The name of the file to save the transactions into without extension.",
+        required=False,
+        default=None
+    )
 
     return arg_parser.parse_args()
 
@@ -110,9 +104,7 @@ if __name__ == "__main__":
 
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)
-    logger.addHandler(
-        screenhandler
-    )
+    logger.addHandler(screenhandler)
 
     transaction_list = []
     parser = None

--- a/deltaconv/converter.py
+++ b/deltaconv/converter.py
@@ -16,14 +16,14 @@ import argparse
 import logging
 import sys
 
-from deltaconv.parser.binance import BinanceParser, BinanceCrawlerParser
+from deltaconv.parser.binance import BinanceTradeParser, BinanceCrawlerParser
 from deltaconv.parser.bitpanda import BitpandaParser
 from deltaconv.parser.delta import DeltaParser
 from deltaconv.parser.parser import ParserOutdatedError
 
 PARSER = {
     'binance': {
-        'parser': BinanceParser,
+        'parser': BinanceTradeParser,
         'config': {
             'delimiter': ",",
         }

--- a/deltaconv/converter.py
+++ b/deltaconv/converter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2016-2018 by Lars Klitzke, Lars.Klitzke@gmail.com
+# Copyright (c) 2016-2019 by Lars Klitzke, Lars.Klitzke@gmail.com
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,14 +16,22 @@ import argparse
 import logging
 import sys
 
-from deltaconv.parser.binance import BinanceTradeParser, BinanceCrawlerParser
+from deltaconv.parser.binance import BinanceTradeParser, BinanceCrawlerTradeParser, BinanceCrawlerDepositParser, \
+    BinanceDepositParser
 from deltaconv.parser.bitpanda import BitpandaParser
 from deltaconv.parser.delta import DeltaParser
 from deltaconv.parser.parser import ParserOutdatedError
 
 PARSER = {
-    'binance': {
+    'binance-trades': {
         'parser': BinanceTradeParser,
+        'config': {
+            'delimiter': ",",
+        }
+    },
+
+    'binance-deposit': {
+        'parser': BinanceDepositParser,
         'config': {
             'delimiter': ",",
         }
@@ -36,8 +44,15 @@ PARSER = {
         }
     },
 
-    'binancecrawler': {
-        'parser': BinanceCrawlerParser,
+    'binancecrawler-trades': {
+        'parser': BinanceCrawlerTradeParser,
+        'config': {
+            'delimiter': ';',
+        }
+    },
+
+    'binancecrawler-deposit': {
+        'parser': BinanceCrawlerDepositParser,
         'config': {
             'delimiter': ';',
         }
@@ -52,7 +67,7 @@ PARSER = {
 }
 
 # The list of available csv file exporter
-EXPORTER = {name: PARSER[name] for name in ['binance', 'delta']}
+# EXPORTER = {name: PARSER[name] for name in ['binance', 'delta']}
 
 
 def parse_arguments():

--- a/deltaconv/crawler.py
+++ b/deltaconv/crawler.py
@@ -210,8 +210,22 @@ class BinanceConnection(object):
 
         return result['data']
 
-    def _get_exchanges(self, symbol=None, type=Exchange.DEPOSIT.value):
+    def _get_intervals(self, start: datetime.datetime, end: datetime.datetime):
+        """Split up the interval into equally-sized parts
+
+        Args:
+            start (datetime.datetime): The start time
+            end (datetime.datetime): The end time
+
+        Returns:
+            Tuple[List, List: The lists of start and end times 
         """
+
+        dates = pd.date_range(start, end, freq='4W')
+
+        # ensure the last date is not after the specified end date
+        return dates[:-1], [*dates[1:-1], end]
+
         Retrieve the deposits or withdrawals.
 
         Args:

--- a/deltaconv/crawler.py
+++ b/deltaconv/crawler.py
@@ -16,8 +16,82 @@ import datetime
 import json
 import logging
 import sys
+from enum import Enum
+from typing import Callable
 
 import requests
+
+
+class Mode(Enum):
+    TRADING = "trading"
+    DEPOSIT = "deposit"
+    WITHDRAWAL = "withdrawal"
+
+
+# A list of available run modes
+MODES = {
+    Mode.TRADING.value: None,
+    Mode.DEPOSIT.value: None,
+    Mode.WITHDRAWAL.value: None
+}  # type: dict[str, Callable]
+
+
+def fetch_trades(connection, arguments):
+    """
+    Fetch trades using the given connection
+
+    Args:
+        connection (BinanceConnection): An open connection to Binance.
+        arguments (argparse.Namespace): The command line arguments.
+
+    Returns:
+        list[dict]: A list of trades
+    """
+    try:
+        start_date = datetime.datetime.strptime(arguments.start, '%Y-%m-%d %H:%M:%S')
+    except ValueError:
+        raise ValueError('The given start time format is wrong. Format YYYY-MM-DD HH:MM:SS is required.')
+
+    if not isinstance(arguments.end, datetime.datetime):
+        try:
+            end_date = datetime.datetime.strptime(arguments.end, '%Y-%m-%d %H:%M:%S')
+        except ValueError:
+            raise ValueError('The given end time format is wrong. Format YYYY-MM-DD HH:MM:SS is required.')
+    else:
+        end_date = arguments.end
+
+    return connection.trades(
+        start=start_date,
+        end=end_date,
+    )
+
+
+def fetch_deposits(connection, arguments):
+    """
+    Fetch deposits using the given connection
+
+    Args:
+        connection (BinanceConnection): An open connection to Binance.
+        arguments (argparse.Namespace): The command line arguments.
+
+    Returns:
+        list[dict]: A list of deposits
+    """
+    return connection.deposits()
+
+
+def fetch_withdrawals(connection, arguments):
+    """
+    Fetch deposits using the given connection
+
+    Args:
+        connection (BinanceConnection): An open connection to Binance.
+        arguments (argparse.Namespace): The command line arguments.
+
+    Returns:
+        list[dict]: A list of withdrawals
+    """
+    return connection.withdrawals()
 
 
 def parse_arguments():
@@ -31,27 +105,39 @@ def parse_arguments():
             This tool circumvent the trade history restriction of Binance, due to which only the trade history 
             for a three month interval can be exported.""")
 
-    arg_parser.add_argument('--cookies', help='A file containing the cookies for a Binance session.', required=True)
+    arg_parser.add_argument('--cookies', help='A file containing the cookies for a Binance session.', required=True,
+                            type=argparse.FileType('rt'))
 
     arg_parser.add_argument('--token', help='The csrftoken in the HTTP header.', required=True)
 
     arg_parser.add_argument('--output', help='The name of the CSV file with format.', required=True)
 
-    arg_parser.add_argument('--start', help='The start datetime of the query interval in format YYYY-MM-DD HH:MM:SS',
-                            required=True)
+    arg_parser.add_argument('--mode', choices=MODES, required=True)
 
-    arg_parser.add_argument('--end', help='The end datetime of the query interval. If not specified, the current date '
-                                          'will be used', required=False, default=datetime.datetime.now())
+    group = arg_parser.add_argument_group('Trade history')
 
-    return arg_parser.parse_args()
+    group.add_argument('--start', help='The start datetime of the query interval in format YYYY-MM-DD HH:MM:SS')
+
+    group.add_argument('--end', help='The end datetime of the query interval. If not specified, the current date '
+                                     'will be used', required=False, default=datetime.datetime.now())
+
+    args = arg_parser.parse_args()
+
+    if args.mode == 'trading' and not args.start:
+        arg_parser.error('The --start time is required in "trading" mode.')
+
+    return args
 
 
 class BinanceConnection(object):
-
     # Restricts the number of trades returned per request
     # We are currently sending multiple small requests
     # instead of one huge one to not stress Binance website.
     _MAX_TRADE_QUERY_COUNT = 1000
+
+    class Exchange(Enum):
+        DEPOSIT = 0
+        WITHDRAWAL = 1
 
     def __init__(self, csrftoken, cookies):
         super().__init__()
@@ -86,7 +172,6 @@ class BinanceConnection(object):
         Retrieve the trades between `start` and `end`.
 
         Args:
-            page (int|str):             The page number
             start (datetime.datetime):  The start date
             end (datetime.datetime):    Date of last transaction
             symbol (str):               The symbol to query, e.g. ETH, ADA, etc.
@@ -125,6 +210,41 @@ class BinanceConnection(object):
 
         return result['pages'], result['data']
 
+    def _get_exchanges(self, symbol=None, type=Exchange.DEPOSIT.value):
+        """
+        Retrieve the deposits or withdrawals.
+
+        Args:
+            symbol (str):       The symbol to query, e.g. ETH, ADA, etc.
+            type (Exchange):    The type of exchange; DEPOSIT or WITHDRAWAL.
+
+        Returns:
+            tuple[int, dict]:   A tuple with the number of pages and the data of the specified page
+
+        """
+
+        post_data = {
+            'coin': '' if symbol is None else symbol,
+            'direction': type,
+            # take care of choosing this value - binance may reach out to you if you
+            # set this value too high :P
+            'rows': 0,
+            'page': 1,
+            'status': '',
+        }
+
+        r = requests.post(
+            url='https://www.binance.com/user/getMoneyLog.html',
+            headers=self._headers,
+            allow_redirects=True,
+            data=post_data,
+            cookies=self._cookies
+        )
+
+        result = json.loads(r.text)
+
+        return result['pages'], result['data']
+
     def trades(self, start, end, **kwargs):
         """
         Get all trades between `start` and `end`
@@ -140,6 +260,8 @@ class BinanceConnection(object):
             list: A list of `Transaction`s
 
         """
+
+        logging.info('Get trades from %s to %s', start, end)
 
         # since Binance only allows to retrieve three month in one query, we have to split up the request
         start_interval = start.replace(second=0, minute=0, hour=0, microsecond=0)
@@ -158,51 +280,53 @@ class BinanceConnection(object):
             end_interval = start_interval + datetime.timedelta(days=28)
 
         # handle the last query since the interval should always overlap the full trading interval
-
         _, result = self._get_trades(start_interval, end, **kwargs)
 
         trades.extend(result)
 
         return trades
 
+    def deposits(self, **kwargs):
+
+        logging.info('Get all deposits')
+
+        _, result = self._get_exchanges(type=self.Exchange.DEPOSIT.value, **kwargs)
+
+        logging.info('Found %d transactions', len(result))
+        return result
+
+    def withdrawals(self, **kwargs):
+
+        logging.info('Get all withdrawals')
+
+        _, result = self._get_exchanges(type=self.Exchange.WITHDRAWAL.value, **kwargs)
+
+        logging.info('Found %d transactions', len(result))
+
+        return result
+
 
 def main(arguments):
+    # init the mode functions
+    MODES[Mode.TRADING.value] = fetch_trades
+    MODES[Mode.DEPOSIT.value] = fetch_deposits
+    MODES[Mode.WITHDRAWAL.value] = fetch_withdrawals
+
     # read in the cookies
-    with open(arguments.cookies, 'r') as cookie_file:
-        cookies = cookie_file.readlines()[0]
+    cookies = arguments.cookies.readlines()[0]
 
     conn = BinanceConnection(csrftoken=arguments.token, cookies=cookies)
 
-    try:
-        start_date = datetime.datetime.strptime(arguments.start, '%Y-%m-%d %H:%M:%S')
-    except ValueError:
-        raise ValueError('The given start time format is wrong. Format YYYY-MM-DD HH:MM:SS is required.')
+    result = MODES[arguments.mode](conn, arguments)
 
-    if not isinstance(arguments.end, datetime.datetime):
-        try:
-            end_date = datetime.datetime.strptime(arguments.end, '%Y-%m-%d %H:%M:%S')
-        except ValueError:
-            raise ValueError('The given end time format is wrong. Format YYYY-MM-DD HH:MM:SS is required.')
-    else:
-        end_date = arguments.end
+    if result:
+        # now write to the csv file
+        with open(arguments.output, 'w') as file:
+            import csv
 
-    trades = conn.trades(
-        start=start_date,
-        end=end_date,
-    )
-
-    # now write to the csv file
-    with open(arguments.output, 'w') as csvfile:
-        import csv
-
-        writer = csv.writer(csvfile, delimiter=';')
-
-        # use the keys of the first trade as csv file header
-        writer.writerow(trades[0].keys())
-
-        # just export all entries as rows
-        for entry in trades:
-            writer.writerow(entry.values())
+            writer = csv.DictWriter(file, fieldnames=result[0].keys(), delimiter=';')
+            writer.writeheader()
+            writer.writerows(result)
 
 
 if __name__ == '__main__':

--- a/deltaconv/crawler.py
+++ b/deltaconv/crawler.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2016-2018 by Lars Klitzke, Lars.Klitzke@gmail.com
+# Copyright (c) 2016-2019 by Lars Klitzke, Lars.Klitzke@gmail.com
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/deltaconv/crawler.py
+++ b/deltaconv/crawler.py
@@ -287,6 +287,16 @@ class BinanceConnection(object):
         return trades
 
     def deposits(self, **kwargs):
+        """
+        Get all deposits.
+
+        Args:
+            **kwargs:
+
+        Returns:
+            list[dict[str:any]]: A list transactions
+
+        """
 
         logging.info('Get all deposits')
 
@@ -296,6 +306,16 @@ class BinanceConnection(object):
         return result
 
     def withdrawals(self, **kwargs):
+        """
+        Get all withdrawals.
+
+        Args:
+            **kwargs:
+
+        Returns:
+            list[dict[str:any]]: A list transactions
+
+        """
 
         logging.info('Get all withdrawals')
 

--- a/deltaconv/crawler.py
+++ b/deltaconv/crawler.py
@@ -272,9 +272,7 @@ class BinanceConnection(object):
 
         result = json.loads(r.text)['data']
 
-        logging.info('Found %d transactions', len(result))
-
-        return result['data']
+        return result
 
     def _get_exchanges(self, start: datetime.datetime, end: datetime.datetime, type, symbol=None):
         """

--- a/deltaconv/crawler.py
+++ b/deltaconv/crawler.py
@@ -312,8 +312,6 @@ class BinanceConnection(object):
 
         result = json.loads(r.text)['data']['rows']
 
-        logging.info('Found %d transactions', len(result))
-
         return result
 
     def _query(self, start: datetime.datetime, end: datetime.datetime, func, *args, **kwargs):
@@ -329,6 +327,8 @@ class BinanceConnection(object):
                     trades.extend(t_trades)
             except JSONDecodeError:
                 pass
+
+        logging.info('Found %d transactions', len(trades))
 
         return trades
 

--- a/deltaconv/parser/binance.py
+++ b/deltaconv/parser/binance.py
@@ -49,7 +49,7 @@ def _market_to_trading_pair(market):
             return __get_currencies(second_symbol, c.symbol)
 
 
-class BinanceParser(TradeHistoryParser):
+class BinanceTradeParser(TradeHistoryParser):
     """
     Parses csv files of the Binance exchange platform.
 

--- a/deltaconv/parser/binance.py
+++ b/deltaconv/parser/binance.py
@@ -385,7 +385,6 @@ class BinanceCrawlerTradeParser(TradeHistoryParser):
     _COLUMN_REALPnl = 'realPnl'
     _COLUMN_QUOTE_ASSET = 'quoteAsset'
     _COLUMN_BASE_ASSET = 'baseAsset'
-    _COLUMN_ID = 'id'
     _COLUMN_FEE = 'fee'
     _COLUMN_PRICE = 'price'
     _COLUMN_ACTIVE_BUY = 'activeBuy'

--- a/deltaconv/parser/binance.py
+++ b/deltaconv/parser/binance.py
@@ -170,7 +170,7 @@ class BinanceDepositParser(TradeHistoryParser):
 
     """
 
-    _COLUMN_DATE = "Date"
+    _COLUMN_DATE = "Date(UTC)"
 
     _COLUMN_COIN = "Coin"
 
@@ -182,7 +182,7 @@ class BinanceDepositParser(TradeHistoryParser):
 
     _COLUMN_TXID = "TXID"
 
-    _COLUMN_SOURCE_ADDRESS = "Source Address"
+    _COLUMN_SOURCE_ADDRESS = "SourceAddress"
 
     _COLUMN_PAYMENT_ID = "PaymentID"
 
@@ -252,7 +252,7 @@ class BinanceDepositParser(TradeHistoryParser):
             row = TradeHistoryParser.Row(self._COLUMNS)
 
             values = {
-                self._COLUMN_DATE: d.timestamp.strftime("%Y-%m-%d %H-%M-%S"),
+                self._COLUMN_DATE: d.timestamp.strftime("%Y-%m-%d %H:%M:%S"),
                 self._COLUMN_COIN: d.currency,
                 self._COLUMN_AMOUNT: d.amount,
                 self._COLUMN_TRANSACTIONFEE: d.transactionfee.amount,
@@ -267,7 +267,7 @@ class BinanceDepositParser(TradeHistoryParser):
 
             transactions.append(values)
 
-        self._write_transactions(transactions, "{}.xlsx".format(file))
+        self._write_transactions(transactions=transactions, columns=self._COLUMNS, file="{}.xlsx".format(file))
 
 
 class BinanceCrawlerDepositParser(TradeHistoryParser):
@@ -277,7 +277,6 @@ class BinanceCrawlerDepositParser(TradeHistoryParser):
     """
 
     _COLUMN_TXID = "txId"
-    _COLUMN_DIRECTION = "direction"
     _COLUMN_COIN = "coin"
     _COLUMN_CURRENT_CONFIRM_TIMES = "curConfirmTimes"
     _COLUMN_STATUS = "status"
@@ -287,19 +286,14 @@ class BinanceCrawlerDepositParser(TradeHistoryParser):
     _COLUMN_USER_ID = "userId"
     _COLUMN_ADDRESS = "address"
     _COLUMN_AMOUNT_TRANSFER = "transferAmount"
-    _COLUMN_URL = "url"
+    _COLUMN_URL = "txUrl"
     _COLUMN_ADDRESS_URL = "addressUrl"
-    _COLUMN_INFO = "info"
     _COLUMN_ADDRESS_TAG = "addressTag"
-    _COLUMN_APPLY_TIME = "applyTime"
+    _COLUMN_APPLY_TIME = "insertTime"
     _COLUMN_STATUS_NAME = "statusName"
-    _COLUMN_DIRECTION_NAME = "directionName"
-    _COLUMN_APPLY_TIME_STR = "applyTimeStr"
-    _COLUMN_TRANSACTION_FEE = "transactionFee"
 
     _COLUMNS = [
         _COLUMN_TXID,
-        _COLUMN_DIRECTION,
         _COLUMN_COIN,
         _COLUMN_CURRENT_CONFIRM_TIMES,
         _COLUMN_STATUS,
@@ -311,13 +305,9 @@ class BinanceCrawlerDepositParser(TradeHistoryParser):
         _COLUMN_AMOUNT_TRANSFER,
         _COLUMN_URL,
         _COLUMN_ADDRESS_URL,
-        _COLUMN_INFO,
         _COLUMN_ADDRESS_TAG,
         _COLUMN_APPLY_TIME,
-        _COLUMN_STATUS_NAME,
-        _COLUMN_DIRECTION_NAME,
-        _COLUMN_APPLY_TIME_STR,
-        _COLUMN_TRANSACTION_FEE,
+        _COLUMN_STATUS_NAME
     ]
 
     def parse(self, csv_file):
@@ -360,12 +350,12 @@ class BinanceCrawlerDepositParser(TradeHistoryParser):
         row_ = TradeHistoryParser.Row(row=row, header=header)
 
         return Deposit(
-            timestamp=datetime.datetime.utcfromtimestamp(row_[cls._COLUMN_APPLY_TIME]),
+            timestamp=datetime.datetime.utcfromtimestamp(row_[cls._COLUMN_APPLY_TIME] / 1E3),
             address=row_[cls._COLUMN_ADDRESS],
             txid=row_[cls._COLUMN_TXID],
             coin=row_[cls._COLUMN_COIN],
             amount=row_[cls._COLUMN_AMOUNT_TRANSFER],
-            fee=Fee(amount=row_[cls._COLUMN_TRANSACTION_FEE], currency=""),
+            fee=Fee(amount=0, currency=""),
             status=row_[cls._COLUMN_STATUS],
             exchange="Binance",
         )

--- a/deltaconv/parser/binance.py
+++ b/deltaconv/parser/binance.py
@@ -114,15 +114,19 @@ class BinanceTradeParser(TradeHistoryParser):
                 row_[self._COLUMN_DATE] = datetime.datetime.strptime(row_[self._COLUMN_DATE], "%d.%m.%y %H:%M")
 
             # convert the row to a transaction
-            transactions.append(CryptoTransaction(
-                datetime=row_[self._COLUMN_DATE],
-                trading_pair=(Position(amount=row_[self._COLUMN_TOTAL], currency=quota),
-                              Position(amount=row_[self._COLUMN_COIN_AMOUNT], currency=base)),
-                trading_type=row_[self._COLUMN_TYPE],
-                price=row_[self._COLUMN_PRICE],
-                fee=Fee(row_[self._COLUMN_FEE], row_[self._COLUMN_FEE_COIN]),
-                exchange="Binance"
-            ))
+            transactions.append(
+                CryptoTransaction(
+                    datetime=row_[self._COLUMN_DATE],
+                    trading_pair=(
+                        Position(amount=row_[self._COLUMN_TOTAL], currency=quota),
+                        Position(amount=row_[self._COLUMN_COIN_AMOUNT], currency=base)
+                    ),
+                    trading_type=row_[self._COLUMN_TYPE],
+                    price=row_[self._COLUMN_PRICE],
+                    fee=Fee(row_[self._COLUMN_FEE], row_[self._COLUMN_FEE_COIN]),
+                    exchange="Binance"
+                )
+            )
 
         return transactions
 
@@ -144,9 +148,7 @@ class BinanceTradeParser(TradeHistoryParser):
 
             values = {
                 self._COLUMN_DATE: t.datetime.strftime("%Y-%m-%d %H:%M:%S"),
-
-                self._COLUMN_MARKET: "{}{}".format(t.trading_pair[1].currency.upper(),
-                                                   t.trading_pair[0].currency),
+                self._COLUMN_MARKET: "{}{}".format(t.trading_pair[1].currency.upper(), t.trading_pair[0].currency),
                 self._COLUMN_TYPE: t.type.upper(),
                 self._COLUMN_PRICE: t.price,
                 self._COLUMN_COIN_AMOUNT: t.trading_pair[1].amount,
@@ -251,7 +253,6 @@ class BinanceDepositParser(TradeHistoryParser):
 
             values = {
                 self._COLUMN_DATE: d.timestamp.strftime("%Y-%m-%d %H-%M-%S"),
-
                 self._COLUMN_COIN: d.currency,
                 self._COLUMN_AMOUNT: d.amount,
                 self._COLUMN_TRANSACTIONFEE: d.transactionfee.amount,
@@ -331,7 +332,8 @@ class BinanceCrawlerDepositParser(TradeHistoryParser):
             # check if each entry in the header is in our list
             # otherwise, rise an exception that the parser is out of date
             raise ParserOutdatedError(
-                'The columns {} are unknown. The parser has to be updated!'.format(missing_columns))
+                'The columns {} are unknown. The parser has to be updated!'.format(missing_columns)
+            )
 
         return [self.convert(row, header) for row in csv_content]
 
@@ -400,7 +402,6 @@ class BinanceCrawlerTradeParser(TradeHistoryParser):
         _COLUMN_REALPnl,
         _COLUMN_QUOTE_ASSET,
         _COLUMN_BASE_ASSET,
-        _COLUMN_ID,
         _COLUMN_FEE,
         _COLUMN_PRICE,
         _COLUMN_ACTIVE_BUY,
@@ -422,7 +423,8 @@ class BinanceCrawlerTradeParser(TradeHistoryParser):
             #     if c not in BinanceCrawlerTradeParser._COLUMNS:
             # otherwise, rise an exception that the parser is out of date
             raise ParserOutdatedError(
-                'The columns {} are unknown. The parser has to be updated!'.format(missing_columns))
+                'The columns {} are unknown. The parser has to be updated!'.format(missing_columns)
+            )
 
         return [self.convert(row, header) for row in csv_content]
 
@@ -452,8 +454,10 @@ class BinanceCrawlerTradeParser(TradeHistoryParser):
 
         return CryptoTransaction(
             datetime=datetime.datetime.utcfromtimestamp(row_[BinanceCrawlerTradeParser._COLUMN_TIME] / 1000),
-            trading_pair=(Position(amount=row_[BinanceCrawlerTradeParser._COLUMN_TOTAL_QUOTA], currency=quota),
-                          Position(amount=row_[BinanceCrawlerTradeParser._COLUMN_QUANTITY], currency=base)),
+            trading_pair=(
+                Position(amount=row_[BinanceCrawlerTradeParser._COLUMN_TOTAL_QUOTA], currency=quota),
+                Position(amount=row_[BinanceCrawlerTradeParser._COLUMN_QUANTITY], currency=base)
+            ),
             trading_type=row_[BinanceCrawlerTradeParser._COLUMN_SIDE],
             price=row_[BinanceCrawlerTradeParser._COLUMN_PRICE],
             fee=Fee(row_[BinanceCrawlerTradeParser._COLUMN_FEE], row_[BinanceCrawlerTradeParser._COLUMN_FEE_COIN]),

--- a/deltaconv/parser/binance.py
+++ b/deltaconv/parser/binance.py
@@ -13,7 +13,7 @@
 # GNU General Public License for more details.
 import datetime
 
-from deltaconv.transaction import CryptoList, Position, Fee, CryptoTransaction
+from deltaconv.transaction import CryptoList, Position, Fee, CryptoTransaction, Deposit
 from .parser import TradeHistoryParser, ParserOutdatedError
 
 
@@ -143,7 +143,7 @@ class BinanceTradeParser(TradeHistoryParser):
             row = TradeHistoryParser.Row(self._COLUMNS)
 
             values = {
-                self._COLUMN_DATE: t.datetime.strftime("%Y-%m-%d %H-%M-%S"),
+                self._COLUMN_DATE: t.datetime.strftime("%Y-%m-%d %H:%M:%S"),
 
                 self._COLUMN_MARKET: "{}{}".format(t.trading_pair[1].currency.upper(),
                                                    t.trading_pair[0].currency),
@@ -159,10 +159,227 @@ class BinanceTradeParser(TradeHistoryParser):
 
             transactions.append(values)
 
-        self._write_transactions(transactions, "{}.xlsx".format(csv_file))
+        self._write_transactions(transactions=transactions, columns=self._COLUMNS, file="{}.xlsx".format(csv_file))
 
 
-class BinanceCrawlerParser(TradeHistoryParser):
+class BinanceDepositParser(TradeHistoryParser):
+    """
+    Parses deposit files of the Binance exchange platform.
+
+    """
+
+    _COLUMN_DATE = "Date"
+
+    _COLUMN_COIN = "Coin"
+
+    _COLUMN_AMOUNT = "Amount"
+
+    _COLUMN_TRANSACTIONFEE = "TransactionFee"
+
+    _COLUMN_ADDRESS = "Address"
+
+    _COLUMN_TXID = "TXID"
+
+    _COLUMN_SOURCE_ADDRESS = "Source Address"
+
+    _COLUMN_PAYMENT_ID = "PaymentID"
+
+    _COLUMN_STATUS = "Status"
+
+    _COLUMNS = [
+        _COLUMN_DATE,
+        _COLUMN_COIN,
+        _COLUMN_AMOUNT,
+        _COLUMN_TRANSACTIONFEE,
+        _COLUMN_ADDRESS,
+        _COLUMN_TXID,
+        _COLUMN_SOURCE_ADDRESS,
+        _COLUMN_PAYMENT_ID,
+        _COLUMN_STATUS
+    ]
+
+    def parse(self, file):
+
+        content = self._read_file(file)
+
+        # the first line is the header of the csv columns
+        header = content[0]
+        del content[0]
+
+        # check if each entry in the header is in our list
+        for c in header:
+            if c not in self._COLUMNS:
+                # otherwise, rise an exception that the parser is out of date
+                raise ParserOutdatedError('The column {} is unknown. The parser has to be updated!'.format(c))
+
+        deposits = []
+
+        # parse all other rows
+        for row in content:
+            row_ = TradeHistoryParser.Row(row=row, header=header)
+
+            d = Deposit(
+                timestamp=row_[self._COLUMN_DATE],
+                address=row_[self._COLUMN_ADDRESS],
+                txid=row_[self._COLUMN_TXID],
+                coin=row_[self._COLUMN_COIN],
+                amount=row_[self._COLUMN_AMOUNT],
+                fee=Fee(amount=row_[self._COLUMN_TRANSACTIONFEE], currency=""),
+                status=row_[self._COLUMN_STATUS],
+                exchange="Binance",
+            )
+
+            deposits.append(d)
+
+        return deposits
+
+    def export(self, deposits, file):
+        """
+        Write the list of `Deposit` into the given `file`.
+
+        Args:
+            deposits (list[Deposit]): A list of `Deposit`s.
+            file (str): The path for the file
+        """
+
+        transactions = []
+
+        deposits = sorted(deposits, key=lambda d: d.timestamp)
+
+        for d in deposits:
+            row = TradeHistoryParser.Row(self._COLUMNS)
+
+            values = {
+                self._COLUMN_DATE: d.timestamp.strftime("%Y-%m-%d %H-%M-%S"),
+
+                self._COLUMN_COIN: d.currency,
+                self._COLUMN_AMOUNT: d.amount,
+                self._COLUMN_TRANSACTIONFEE: d.transactionfee.amount,
+                self._COLUMN_ADDRESS: d.address,
+                self._COLUMN_TXID: d.txid,
+                self._COLUMN_SOURCE_ADDRESS: "",
+                self._COLUMN_PAYMENT_ID: "",
+                self._COLUMN_STATUS: d.status
+            }
+
+            row.update(values)
+
+            transactions.append(values)
+
+        self._write_transactions(transactions, "{}.xlsx".format(file))
+
+
+class BinanceCrawlerDepositParser(TradeHistoryParser):
+    """
+    Parses deposits from the BinanceCrawler.
+
+    """
+
+    _COLUMN_TXID = "txId"
+    _COLUMN_DIRECTION = "direction"
+    _COLUMN_COIN = "coin"
+    _COLUMN_CURRENT_CONFIRM_TIMES = "curConfirmTimes"
+    _COLUMN_STATUS = "status"
+    _COLUMN_ID = "id"
+    _COLUMN_CONFIRM_TIMES = "confirmTimes"
+    _COLUMN_ASSET_LABEL = "assetLabel"
+    _COLUMN_USER_ID = "userId"
+    _COLUMN_ADDRESS = "address"
+    _COLUMN_AMOUNT_TRANSFER = "transferAmount"
+    _COLUMN_URL = "url"
+    _COLUMN_ADDRESS_URL = "addressUrl"
+    _COLUMN_INFO = "info"
+    _COLUMN_ADDRESS_TAG = "addressTag"
+    _COLUMN_APPLY_TIME = "applyTime"
+    _COLUMN_STATUS_NAME = "statusName"
+    _COLUMN_DIRECTION_NAME = "directionName"
+    _COLUMN_APPLY_TIME_STR = "applyTimeStr"
+    _COLUMN_TRANSACTION_FEE = "transactionFee"
+
+    _COLUMNS = [
+        _COLUMN_TXID,
+        _COLUMN_DIRECTION,
+        _COLUMN_COIN,
+        _COLUMN_CURRENT_CONFIRM_TIMES,
+        _COLUMN_STATUS,
+        _COLUMN_ID,
+        _COLUMN_CONFIRM_TIMES,
+        _COLUMN_ASSET_LABEL,
+        _COLUMN_USER_ID,
+        _COLUMN_ADDRESS,
+        _COLUMN_AMOUNT_TRANSFER,
+        _COLUMN_URL,
+        _COLUMN_ADDRESS_URL,
+        _COLUMN_INFO,
+        _COLUMN_ADDRESS_TAG,
+        _COLUMN_APPLY_TIME,
+        _COLUMN_STATUS_NAME,
+        _COLUMN_DIRECTION_NAME,
+        _COLUMN_APPLY_TIME_STR,
+        _COLUMN_TRANSACTION_FEE,
+    ]
+
+    def parse(self, csv_file):
+        csv_content = self._read_file(csv_file)
+
+        # the first line is the header of the csv columns
+        header = csv_content[0]
+        del csv_content[0]
+
+        missing_columns = list(set(self._COLUMNS) - set(header))
+        if missing_columns:
+            # check if each entry in the header is in our list
+            # otherwise, rise an exception that the parser is out of date
+            raise ParserOutdatedError(
+                'The columns {} are unknown. The parser has to be updated!'.format(missing_columns))
+
+        return [self.convert(row, header) for row in csv_content]
+
+    @classmethod
+    def convert(cls, row, header):
+        """
+        Converts the given `row` into a `Transaction`
+
+        Args:
+            row (list):     The row as a list of values
+            header (list):  Description of each row entry
+
+        Notes:
+            The list lengths of row and header have to equal.
+
+        Returns:
+            CryptoTransaction:  The row converted into a CryptoTransaction
+
+        """
+        assert len(row) == len(header), 'Each column must have an entry in the header!'
+        assert isinstance(row, list), 'The row should be a list'
+        assert isinstance(header, list), 'The header should be list'
+
+        row_ = TradeHistoryParser.Row(row=row, header=header)
+
+        return Deposit(
+            timestamp=datetime.datetime.utcfromtimestamp(row_[cls._COLUMN_APPLY_TIME]),
+            address=row_[cls._COLUMN_ADDRESS],
+            txid=row_[cls._COLUMN_TXID],
+            coin=row_[cls._COLUMN_COIN],
+            amount=row_[cls._COLUMN_AMOUNT_TRANSFER],
+            fee=Fee(amount=row_[cls._COLUMN_TRANSACTION_FEE], currency=""),
+            status=row_[cls._COLUMN_STATUS],
+            exchange="Binance",
+        )
+
+        # return CryptoTransaction(
+        #     datetime=datetime.datetime.utcfromtimestamp(row_[BinanceCrawlerTradeParser._COLUMN_TIME] / 1000),
+        #     trading_pair=(Position(amount=row_[BinanceCrawlerTradeParser._COLUMN_TOTAL_QUOTA], currency=quota),
+        #                   Position(amount=row_[BinanceCrawlerTradeParser._COLUMN_QUANTITY], currency=base)),
+        #     trading_type=row_[BinanceCrawlerTradeParser._COLUMN_SIDE],
+        #     price=row_[BinanceCrawlerTradeParser._COLUMN_PRICE],
+        #     fee=Fee(row_[BinanceCrawlerTradeParser._COLUMN_FEE], row_[BinanceCrawlerTradeParser._COLUMN_FEE_COIN]),
+        #     exchange="Binance"
+        # )
+
+
+class BinanceCrawlerTradeParser(TradeHistoryParser):
     """
     Parses csv files created by the binanceCrawler.
 
@@ -201,7 +418,6 @@ class BinanceCrawlerParser(TradeHistoryParser):
     ]
 
     def parse(self, csv_file):
-
         csv_content = self._read_file(csv_file)
 
         # the first line is the header of the csv columns
@@ -214,7 +430,7 @@ class BinanceCrawlerParser(TradeHistoryParser):
             #
             # # check if each entry in the header is in our list
             # for c in header:
-            #     if c not in BinanceCrawlerParser._COLUMNS:
+            #     if c not in BinanceCrawlerTradeParser._COLUMNS:
             # otherwise, rise an exception that the parser is out of date
             raise ParserOutdatedError(
                 'The columns {} are unknown. The parser has to be updated!'.format(missing_columns))
@@ -246,15 +462,11 @@ class BinanceCrawlerParser(TradeHistoryParser):
         base, quota = row_[cls._COLUMN_BASE_ASSET], row_[cls._COLUMN_QUOTE_ASSET]
 
         return CryptoTransaction(
-            datetime=datetime.datetime.utcfromtimestamp(row_[BinanceCrawlerParser._COLUMN_TIME] / 1000),
-            trading_pair=(Position(amount=row_[BinanceCrawlerParser._COLUMN_TOTAL_QUOTA], currency=quota),
-                          Position(amount=row_[BinanceCrawlerParser._COLUMN_QUANTITY], currency=base)),
-            trading_type=row_[BinanceCrawlerParser._COLUMN_SIDE],
-            price=row_[BinanceCrawlerParser._COLUMN_PRICE],
-            fee=Fee(row_[BinanceCrawlerParser._COLUMN_FEE], row_[BinanceCrawlerParser._COLUMN_FEE_COIN]),
+            datetime=datetime.datetime.utcfromtimestamp(row_[BinanceCrawlerTradeParser._COLUMN_TIME] / 1000),
+            trading_pair=(Position(amount=row_[BinanceCrawlerTradeParser._COLUMN_TOTAL_QUOTA], currency=quota),
+                          Position(amount=row_[BinanceCrawlerTradeParser._COLUMN_QUANTITY], currency=base)),
+            trading_type=row_[BinanceCrawlerTradeParser._COLUMN_SIDE],
+            price=row_[BinanceCrawlerTradeParser._COLUMN_PRICE],
+            fee=Fee(row_[BinanceCrawlerTradeParser._COLUMN_FEE], row_[BinanceCrawlerTradeParser._COLUMN_FEE_COIN]),
             exchange="Binance"
         )
-
-    def __init__(self, **kwargs):
-
-        super().__init__(**kwargs)

--- a/deltaconv/parser/binance.py
+++ b/deltaconv/parser/binance.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2016-2018 by Lars Klitzke, Lars.Klitzke@gmail.com
+# Copyright (c) 2016-2019 by Lars Klitzke, Lars.Klitzke@gmail.com
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -367,16 +367,6 @@ class BinanceCrawlerDepositParser(TradeHistoryParser):
             status=row_[cls._COLUMN_STATUS],
             exchange="Binance",
         )
-
-        # return CryptoTransaction(
-        #     datetime=datetime.datetime.utcfromtimestamp(row_[BinanceCrawlerTradeParser._COLUMN_TIME] / 1000),
-        #     trading_pair=(Position(amount=row_[BinanceCrawlerTradeParser._COLUMN_TOTAL_QUOTA], currency=quota),
-        #                   Position(amount=row_[BinanceCrawlerTradeParser._COLUMN_QUANTITY], currency=base)),
-        #     trading_type=row_[BinanceCrawlerTradeParser._COLUMN_SIDE],
-        #     price=row_[BinanceCrawlerTradeParser._COLUMN_PRICE],
-        #     fee=Fee(row_[BinanceCrawlerTradeParser._COLUMN_FEE], row_[BinanceCrawlerTradeParser._COLUMN_FEE_COIN]),
-        #     exchange="Binance"
-        # )
 
 
 class BinanceCrawlerTradeParser(TradeHistoryParser):

--- a/deltaconv/parser/bitpanda.py
+++ b/deltaconv/parser/bitpanda.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2016-2018 by Lars Klitzke, Lars.Klitzke@gmail.com
+# Copyright (c) 2016-2019 by Lars Klitzke, Lars.Klitzke@gmail.com
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/deltaconv/parser/bitpanda.py
+++ b/deltaconv/parser/bitpanda.py
@@ -77,19 +77,22 @@ class BitpandaParser(TradeHistoryParser):
             if row_[self._COLUMN_TYPE] in ['buy', 'sell']:
                 # only process buy and sells
 
-                transactions.append(CryptoTransaction(
-                    datetime=row_[self._COLUMN_DATE],
-                    trading_pair=(Position(amount=row_[self._COLUMN_FIAT_AMOUNT], currency=row_[self._COLUMN_FIAT]),
-                                  Position(amount=row_[self._COLUMN_CRYPTO_AMOUNT],
-                                           currency=row_[self._COLUMN_CRYPTO])),
-                    trading_type=row_[self._COLUMN_TYPE],
+                transactions.append(
+                    CryptoTransaction(
+                        datetime=row_[self._COLUMN_DATE],
+                        trading_pair=(
+                            Position(amount=row_[self._COLUMN_FIAT_AMOUNT], currency=row_[self._COLUMN_FIAT]),
+                            Position(amount=row_[self._COLUMN_CRYPTO_AMOUNT], currency=row_[self._COLUMN_CRYPTO])
+                        ),
+                        trading_type=row_[self._COLUMN_TYPE],
 
-                    # calculate the price based on the amount of fiat used to buy a certain amount of cryptocoins
-                    price=row_[self._COLUMN_FIAT_AMOUNT] / row_[self._COLUMN_CRYPTO_AMOUNT],
+                # calculate the price based on the amount of fiat used to buy a certain amount of cryptocoins
+                        price=row_[self._COLUMN_FIAT_AMOUNT] / row_[self._COLUMN_CRYPTO_AMOUNT],
 
-                    # we actually cannot calculate the fee using the data provided by bitpanda
-                    fee=Fee(0, row_[self._COLUMN_FIAT]),
-                    exchange="Bitpanda"
-                ))
+                # we actually cannot calculate the fee using the data provided by bitpanda
+                        fee=Fee(0, row_[self._COLUMN_FIAT]),
+                        exchange="Bitpanda"
+                    )
+                )
 
         return transactions

--- a/deltaconv/parser/delta.py
+++ b/deltaconv/parser/delta.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2016-2018 by Lars Klitzke, Lars.Klitzke@gmail.com
+# Copyright (c) 2016-2019 by Lars Klitzke, Lars.Klitzke@gmail.com
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/deltaconv/parser/delta.py
+++ b/deltaconv/parser/delta.py
@@ -17,9 +17,6 @@ from .parser import TradeHistoryParser
 
 class DeltaParser(TradeHistoryParser):
 
-    def parse(self, csv_file):
-        super().parse(csv_file=csv_file)
-
     # This field contains the date and time of the transaction, including the timezone.
     _COLUMN_DATE = "Date"
 

--- a/deltaconv/parser/parser.py
+++ b/deltaconv/parser/parser.py
@@ -161,7 +161,7 @@ class TradeHistoryParser(object):
 
             return result
 
-    def _write_transactions(self, transactions, file):
+    def _write_transactions(self, columns, transactions, file):
         """
         Write the transactions into the given file
 
@@ -186,13 +186,13 @@ class TradeHistoryParser(object):
                 sheet = wb.add_sheet('sheet1')
 
                 # write the header
-                for c, head in enumerate(transactions[0].keys()):
+                for c, head in enumerate(columns):
                     sheet.write(0, c, head)
 
                 # write all values
                 for row, transaction in enumerate(transactions):
-                    for col, value in enumerate(transaction.values()):
-                        sheet.write(row + 1, col, value)
+                    for col, value in enumerate(columns):
+                        sheet.write(row + 1, col, transaction[value])
 
                 wb.save(file)
 
@@ -202,7 +202,14 @@ class TradeHistoryParser(object):
 
                     writer = csv.DictWriter(file_, fieldnames=transactions[0].keys(), **self._cfg)
                     writer.writeheader()
-                    writer.writerows(transactions)
+
+                    for t in transactions:
+
+                        for key, value in t.items():
+                            if isinstance(value, float):
+                                t[key] = "{:f}".format(value)
+
+                        writer.writerow(t)
             else:
                 raise NotImplementedError(
                     'The file format {} is currently not supported.'.format(os.path.splitext(file)[1]))

--- a/deltaconv/parser/parser.py
+++ b/deltaconv/parser/parser.py
@@ -201,7 +201,7 @@ class TradeHistoryParser(object):
                 with open(file, mode='w') as file_:
 
                     writer = csv.DictWriter(file_, fieldnames=transactions[0].keys(), **self._cfg)
-
+                    writer.writeheader()
                     writer.writerows(transactions)
             else:
                 raise NotImplementedError(

--- a/deltaconv/transaction.py
+++ b/deltaconv/transaction.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2016-2018 by Lars Klitzke, Lars.Klitzke@gmail.com
+# Copyright (c) 2016-2019 by Lars Klitzke, Lars.Klitzke@gmail.com
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/deltaconv/transaction.py
+++ b/deltaconv/transaction.py
@@ -268,3 +268,66 @@ class CryptoTransaction(Transaction):
 
         """
         return self._exchange
+
+
+class Deposit(Position):
+    """
+    A Deposit is a special kind of position.
+    """
+
+    def __init__(self, timestamp, address, txid, exchange, coin, amount, fee, status):
+        """
+
+        Args:
+            timestamp (datetime.datetime):  The transaction timestamp.
+            address (str):                  The address of the wallet
+            txid (str):                     The transaction id
+            exchange (str):                 The name of the exchange
+            coin (str):                     The name of the coin
+            amount (float):                 The amount of coin transferred
+            fee (Fee):                      The transaction fee
+            status (str):                   The status of the transaction
+        """
+        super().__init__(amount=amount, currency=coin)
+
+        self._timestamp = timestamp
+        self._address = address
+        self._txid = txid
+        self._exchange = exchange
+        self._transactionfee = fee
+        self._status = status
+
+    @property
+    def timestamp(self):
+        return self._timestamp
+
+    @property
+    def address(self):
+        return self._address
+
+    @property
+    def txid(self):
+        return self._txid
+
+    @property
+    def exchange(self):
+        return self._exchange
+
+    @property
+    def transactionfee(self):
+        return self._transactionfee
+
+    @property
+    def status(self):
+        return "Completed" if self._status == 1 else ""
+
+    def __repr__(self):
+        return ", ".join([self.timestamp,
+                          self.exchange,
+                          self.txid,
+                          self.address,
+                          self.currency,
+                          self.status,
+                          str(self.amount),
+                          self.transactionfee.currency,
+                          str(self.transactionfee.amount)])


### PR DESCRIPTION
For proper analysis of trading, importing the deposits and withdrawals into other application is required. This functionality is implemented in this branch.

For that purpose, the command line arguments of the `binancecrawler` changed slightly. You now have to specify the mode with `--mode` and one of the following options

* *trading*: The trading history will be exported. The start and end time has to be defined.
* *deposit*: The deposit history will be exported.
* *withdrawal*: The withdrawal history will be exported.

For further details, see the `--help` of `binancecrawler`.
